### PR TITLE
unit setting now sticks even after restarting the app

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,8 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="$APPLICATION_HOME_DIR$/gradle/gradle-2.14.1" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,9 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/Measure.iml" filepath="$PROJECT_DIR$/Measure.iml" />
       <module fileurl="file://$PROJECT_DIR$/MeasureIt.iml" filepath="$PROJECT_DIR$/MeasureIt.iml" />
+      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/MeasureIt" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/abcmeasurecorp/com/measureit/Activities/MainActivity.java
+++ b/app/src/main/java/abcmeasurecorp/com/measureit/Activities/MainActivity.java
@@ -2,6 +2,7 @@ package abcmeasurecorp.com.measureit.activities;
 
 import android.animation.ArgbEvaluator;
 import android.animation.ObjectAnimator;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
@@ -28,11 +29,14 @@ public class MainActivity extends AppCompatActivity {
     private AppCompatButton mTogglePointerButton;
     private RulerView mRulerView;
     private LinearLayout mRightContainer;
+    private SharedPreferences prefs;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        prefs = getPreferences(MODE_PRIVATE);
 
         mRulerView = (RulerView) findViewById(R.id.ruler);
         mRightContainer = (LinearLayout) findViewById(R.id.right_container);
@@ -43,6 +47,9 @@ public class MainActivity extends AppCompatActivity {
         mTogglePointerButton.setOnClickListener(clickTogglePointer());
         randomColorButton.setOnClickListener(clickRandomColor());
         mUnitsButton.setOnClickListener(clickToggleUnits());
+
+        boolean isMetric = prefs.getBoolean(getString(R.string.ruler_is_metric_pref_key), false);
+        mRulerView.setIsMetric(isMetric);
     }
 
     @Override
@@ -73,11 +80,15 @@ public class MainActivity extends AppCompatActivity {
      */
     private void toggleUnits() {
         String label;
+        SharedPreferences.Editor editor = prefs.edit();
         if (mRulerView.isMetric()) {
             label = getString(R.string.button_metric);
+            editor.putBoolean(getString(R.string.ruler_is_metric_pref_key), false);
         } else {
             label = getString(R.string.button_imperial);
+            editor.putBoolean(getString(R.string.ruler_is_metric_pref_key), true);
         }
+        editor.apply();
         mUnitsButton.setText(label);
         mRulerView.toggleMetric();
     }

--- a/app/src/main/java/abcmeasurecorp/com/measureit/View/RulerView.java
+++ b/app/src/main/java/abcmeasurecorp/com/measureit/View/RulerView.java
@@ -320,6 +320,10 @@ public class RulerView extends View {
         this.invalidate();
     }
 
+    public void setIsMetric(boolean isMetric) {
+        this.mIsMetric = isMetric;
+    }
+
     /**
      * Sets the transparency of the pointer
      *

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="button_metric">Metric Units</string>
     <string name="button_imperial">Imperial Units</string>
     <string name="button_random_color">Random Color!</string>
+    <string name="ruler_is_metric_pref_key">abcmeasurecorp.com.measureit.rulerIsMetric</string>
 </resources>


### PR DESCRIPTION
Added a boolean value to MainActivity preferences that stores whether the user has set the app to metric or stupid units. This setting is then restored upon relaunch of the application.